### PR TITLE
Gauss as unit for magnetic field strength

### DIFF
--- a/misu/misulib.py
+++ b/misu/misulib.py
@@ -307,6 +307,9 @@ createUnit('ton_water ', 1.01832416 * m3)
 createUnit('tun ', 0.953923769568 * m3)
 createUnit('wey_US ', 1.4095628066752 * m3)
 
+# Magnetic field strength
+createUnit('G Gauss', 1e-4 * T)
+
 # Dynamic viscosity
 createUnit('Pa_s pascal_second_SI_unit', 1 * Pa * s, unitCategory='Dynamic viscosity')
 createUnit('poise_cgs_unit ', 0.1 * Pa * s)
@@ -470,7 +473,6 @@ createUnit('dram_avoirdupois  dr_av ', 1.7718451953125 * g)
 createUnit('eV electronvolt', 1.7826e-36 * kg)
 createUnit('gamma ', 1e-6 * g)
 createUnit('gr grain', 64.79891 * mg)
-createUnit('G grave', 1 * kg)
 createUnit('hundredweight_long  long_cwt_or_cwt ', 50.80234544 * kg)
 createUnit('hundredweight_short  cental  sh_cwt ', 45.359237 * kg)
 createUnit('kip', 453.59237 * kg)

--- a/misu/misulib.py
+++ b/misu/misulib.py
@@ -308,7 +308,7 @@ createUnit('tun ', 0.953923769568 * m3)
 createUnit('wey_US ', 1.4095628066752 * m3)
 
 # Magnetic field strength
-createUnit('G Gauss', 1e-4 * T)
+createUnit('G Gauss', 1e-4 * T, mustCreateMetricPrefixes=True)
 
 # Dynamic viscosity
 createUnit('Pa_s pascal_second_SI_unit', 1 * Pa * s, unitCategory='Dynamic viscosity')


### PR DESCRIPTION
Gauss is a very common unit in atomic physics for magnetic field strength. It should be much more used than the quite exotic 'grave G'. I added 'Gauss G' and removed 'grave G'.